### PR TITLE
Fix packet number mapping for OWD plots

### DIFF
--- a/parsers.py
+++ b/parsers.py
@@ -76,8 +76,7 @@ def parse_qlog(log_file):
 
     df = pd.json_normalize(data)
 
-    # TODO: use more sophisticated filtering to filter handshake packets out
-    df = df[df['data.header.packet_number'] >= 2]
+    df = df[df['data.header.packet_type'] == '1RTT']
 
     # add reference time to all relative timestamps
     df["time"] = pd.to_timedelta(df["time"], unit="ms") + reference_time


### PR DESCRIPTION
This filters out packets from other packet number spaces then 1RTT, which is the one we are mostly interested in. Otherwise, OWD might map 1RTT packets to packets from other packet number spaces with the same packet number.